### PR TITLE
Adds support for pre-encoded data types.

### DIFF
--- a/rlp_serializer.h
+++ b/rlp_serializer.h
@@ -57,6 +57,7 @@ typedef enum {
   RLP_TYPE_INT256,
   RLP_TYPE_INT512,
   RLP_TYPE_INT1024,
+  RLP_TYPE_ENCODED_DATA,
 } RlpType_t;
 #define RLP_TYPE_IS_INTEGER_TYPE(x) ((x) >= RLP_TYPE_INT8) && ((x) <= RLP_TYPE_INT1024)
 


### PR DESCRIPTION
These are needed to handle nested arrays, which are used in newer
Ethereum transaction types (EIP1559, EIP2930)